### PR TITLE
update compute for exploratory accounts

### DIFF
--- a/content/english/services/rates.md
+++ b/content/english/services/rates.md
@@ -12,14 +12,14 @@ lead: We provide services with limited resources at **no cost** for PIs, tenure-
 
 | Account(s) Type | Priority | # of User Accounts | CPU Cores | GB in	Home Directory | Cost |
 | --- | --- | --- | --- | --- | --- |
-| Exploratory | Low | 1 | 16 for 48 hours† | 10GB | Free† |
-| Premium | Medium | 1 | 208 for 80 hours‡ | 10GB | $300/quarter |
-| Group Premium | Medium | 6 | 208 for 80 hours (per account)‡ | 10GB/acct | $750/quarter (additional accounts $150/quarter) |
-| HPC Condo | High | 6 | Size of condo | 10GB/acct | Contact us |
+| Exploratory | Low | 1 | 32 for 48 hours† | 20GB | Free† |
+| Premium | Medium | 1 | 208 for 80 hours‡ | 20GB | $300/quarter |
+| Group Premium | Medium | 6 | 208 for 80 hours (per account)‡ | 20GB/acct | $750/quarter (additional accounts $150/quarter) |
+| HPC Condo | High | 6 | Size of condo | 20GB/acct | Contact us |
 
 {{% /table %}}
 
-> † Free exploratory accounts are available to all tenure-track faculty and PIs at Brown. Students and researchers may also obtain an exploratory account with written permission from their advisor or PI. Exploratory accounts have a 16-core limit per user, with a per-job limit of 46,100 core-minutes.
+> † Free exploratory accounts are available to all tenure-track faculty and PIs at Brown. Students and researchers may also obtain an exploratory account with written permission from their advisor or PI. Exploratory accounts have a 16-core limit per user, with a per-job limit of 92,160 core-minutes.
 
 > ‡The maximum number of cores and duration may change based on cluster utilization. Priority accounts each have a Quality-of-Service (QOS) allowing up to 208 cores, 1TB memory, and total per-job limit of 998,400 core-minutes. This allows a 208-core job to run for 80 hours, a 104-core job to run for 160 hours, or 208 1-core jobs to run for 80 hours.
 


### PR DESCRIPTION
Update compute cores to 32 for exploratory accounts and correct storage quota for all accounts. 