### PR TITLE
ci: add pr commenter for prod, add label checks

### DIFF
--- a/.github/CODE_REVIEW/release.md
+++ b/.github/CODE_REVIEW/release.md
@@ -2,7 +2,7 @@
 
 Before merging a pull request into `production`, which triggers a release to the production website, make sure the following is in order:
 
-- [ ] [Staging](datasci.brown.edu) looks as expected for all changes included in this PR
+- [ ] [Staging](https://datasci.brown.edu) looks as expected for all changes included in this PR
 - [ ] Triple check spelling
 - [ ] Triple check links work
 - [ ] Waiting period must be complete (see labels)

--- a/.github/CODE_REVIEW/release.md
+++ b/.github/CODE_REVIEW/release.md
@@ -1,0 +1,8 @@
+## Admin Release Checklist
+
+Before merging a pull request into `production`, which triggers a release to the production website, make sure the following is in order:
+
+- [ ] [Staging](datasci.brown.edu) looks as expected for all changes included in this PR
+- [ ] Triple check spelling
+- [ ] Triple check links work
+- [ ] Waiting period must be complete (see labels)

--- a/.github/workflows/check-waits.yml
+++ b/.github/workflows/check-waits.yml
@@ -4,7 +4,8 @@ on:
   schedule:
     - cron:  '*/15 * * * *'
   push:
-    - chore-pr-comments # FOR TESTING
+    branch:
+      - chore-pr-comments # FOR TESTING
 
 jobs:
   comment:

--- a/.github/workflows/check-waits.yml
+++ b/.github/workflows/check-waits.yml
@@ -3,6 +3,8 @@ name: Check Wait Times
 on:
   schedule:
     - cron:  '*/15 * * * *'
+  push:
+    - chore-pr-comments # FOR TESTING
 
 jobs:
   comment:

--- a/.github/workflows/check-waits.yml
+++ b/.github/workflows/check-waits.yml
@@ -2,13 +2,10 @@ name: Check Wait Times
 
 on:
   schedule:
-    - cron:  '*/15 * * * *'
-  push:
-    branch:
-      - chore-pr-comments # FOR TESTING
+    - cron:  '0 */6 * * *' # every 6 hours
 
 jobs:
-  comment:
+  check:
     runs-on: ubuntu-latest
 
     steps:
@@ -18,16 +15,16 @@ jobs:
       with:
         node-version: 12.x
     - name: Check 4 day waits
-      uses: brown-ccv/gh-actions/check-wait-label@add-wait-label
+      uses: brown-ccv/gh-actions/check-wait-label@master
       with:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         wait_label: "4 day wait"
         wait_time: 4
         done_waiting_label: ready
     - name: Check 2 day waits
-      uses: brown-ccv/gh-actions/check-wait-label@add-wait-label
+      uses: brown-ccv/gh-actions/check-wait-label@master
       with:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         wait_label: "2 day wait"
-        wait_time: 0 # JUST FOR TESTING
+        wait_time: 2
         done_waiting_label: ready

--- a/.github/workflows/check-waits.yml
+++ b/.github/workflows/check-waits.yml
@@ -1,0 +1,30 @@
+name: Check Wait Times
+
+on:
+  schedule:
+    - cron:  '*/15 * * * *'
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+    - name: Check 4 day waits
+      uses: brown-ccv/gh-actions/check-wait-label@add-wait-label
+      with:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        wait_label: "4 day wait"
+        wait_time: 4
+        done_waiting_label: ready
+    - name: Check 2 day waits
+      uses: brown-ccv/gh-actions/check-wait-label@add-wait-label
+      with:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        wait_label: "2 day wait"
+        wait_time: 0 # JUST FOR TESTING
+        done_waiting_label: ready

--- a/.github/workflows/pr-release-comment.yml
+++ b/.github/workflows/pr-release-comment.yml
@@ -29,13 +29,13 @@ jobs:
         message_file: '.github/CODE_REVIEW/release.md'
     - name: Add 4 day wait
       if: contains(steps.pr_type.outputs.change_types, 'feature')
-      uses: brown-ccv/gh-actions/add-pr-labelt@add-wait-label
+      uses: brown-ccv/gh-actions/add-pr-label@add-wait-label
       with:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         label: "4 day wait"
     - name: Add 2 day wait
       if: (!contains(steps.pr_type.outputs.change_types, 'feature'))
-      uses: brown-ccv/gh-actions/add-pr-labelt@add-wait-label
+      uses: brown-ccv/gh-actions/add-pr-label@add-wait-label
       with:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         label: "4 day wait"

--- a/.github/workflows/pr-release-comment.yml
+++ b/.github/workflows/pr-release-comment.yml
@@ -29,15 +29,13 @@ jobs:
         message_file: '.github/CODE_REVIEW/release.md'
     - name: Add 4 day wait
       if: contains(steps.pr_type.outputs.change_types, 'feature')
-      uses: andymckay/labeler@1.0.2
+      uses: brown-ccv/gh-actions/add-pr-labelt@add-wait-label
       with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        add-labels: "4 day wait"
-        ignore-if-assigned: false
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        label: "4 day wait"
     - name: Add 2 day wait
       if: (!contains(steps.pr_type.outputs.change_types, 'feature'))
-      uses: andymckay/labeler@1.0.2
+      uses: brown-ccv/gh-actions/add-pr-labelt@add-wait-label
       with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        add-labels: "2 day wait"
-        ignore-if-assigned: false
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        label: "4 day wait"

--- a/.github/workflows/pr-release-comment.yml
+++ b/.github/workflows/pr-release-comment.yml
@@ -1,0 +1,43 @@
+name: PR Commenter and Labeler - Release
+
+on:
+  pull_request:
+    branch:
+      - production
+      - develop # JUST FOR TESTING
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+    - name: Get PR Change Types
+      id: pr_type
+      uses: brown-ccv/gh-actions/get-pr-type@master
+      with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Release Review Comment PR
+      uses: brown-ccv/gh-actions/comment-pr-checklist@master
+      with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        message_id: "Release"
+        message_file: '.github/CODE_REVIEW/release.md'
+    - name: Add 4 day wait
+      if: contains(steps.pr_type.outputs.change_types, 'feature')
+      uses: andymckay/labeler@1.0.0
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        add-labels: "4 day wait"
+        ignore-if-assigned: false
+    - name: Add 2 day wait
+      if: (!contains(steps.pr_type.outputs.change_types, 'feature'))
+      uses: andymckay/labeler@1.0.0
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        add-labels: "2 day wait"
+        ignore-if-assigned: false

--- a/.github/workflows/pr-release-comment.yml
+++ b/.github/workflows/pr-release-comment.yml
@@ -38,4 +38,4 @@ jobs:
       uses: brown-ccv/gh-actions/add-pr-label@add-wait-label
       with:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-        label: "4 day wait"
+        label: "2 day wait"

--- a/.github/workflows/pr-release-comment.yml
+++ b/.github/workflows/pr-release-comment.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branch:
       - production
-      - develop # JUST FOR TESTING
 
 jobs:
   comment:
@@ -29,13 +28,13 @@ jobs:
         message_file: '.github/CODE_REVIEW/release.md'
     - name: Add 4 day wait
       if: contains(steps.pr_type.outputs.change_types, 'feature')
-      uses: brown-ccv/gh-actions/add-pr-label@add-wait-label
+      uses: brown-ccv/gh-actions/add-pr-label@master
       with:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         label: "4 day wait"
     - name: Add 2 day wait
       if: (!contains(steps.pr_type.outputs.change_types, 'feature'))
-      uses: brown-ccv/gh-actions/add-pr-label@add-wait-label
+      uses: brown-ccv/gh-actions/add-pr-label@master
       with:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         label: "2 day wait"

--- a/.github/workflows/pr-release-comment.yml
+++ b/.github/workflows/pr-release-comment.yml
@@ -29,14 +29,14 @@ jobs:
         message_file: '.github/CODE_REVIEW/release.md'
     - name: Add 4 day wait
       if: contains(steps.pr_type.outputs.change_types, 'feature')
-      uses: andymckay/labeler@1.0.0
+      uses: andymckay/labeler@1.0.2
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         add-labels: "4 day wait"
         ignore-if-assigned: false
     - name: Add 2 day wait
       if: (!contains(steps.pr_type.outputs.change_types, 'feature'))
-      uses: andymckay/labeler@1.0.0
+      uses: andymckay/labeler@1.0.2
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         add-labels: "2 day wait"


### PR DESCRIPTION
### Pull Request
---

#### PR Summary
This PR adds a comment for pull requests to production.  Also adds labels for waiting periods and another action that checks labels and sets things to ready when waiting complete

#### Check the types of changes present in this PR:
- [ ] :bug: Bug
- [ ] :dragon: Feature
- [ ] :frog: Data (data folder - people/opportunities)
- [ ] :dog: Content (content folder)
- [x] :blowfish: Other. Specify: CI

#### Checklist:
- [x] Commitizen was used for all commits.
- [x] Local site looks as expected after changes.
- [x] Contributing guidelines were followed.
- [x] If changes affect development, was the README updated?

##### If PR to `release`
- [ ] Development site (https://brown-ccv.github.io/ccv-website) was checked and looks as expected.

##### If PR to `master`
- [ ] Staging site (https://datasci.brown.edu) was checked and looks as expected.
