### PR TITLE
fix: branches not branch

### DIFF
--- a/.github/workflows/pr-release-comment.yml
+++ b/.github/workflows/pr-release-comment.yml
@@ -2,7 +2,7 @@ name: PR Commenter and Labeler - Release
 
 on:
   pull_request:
-    branch:
+    branches:
       - production
 
 jobs:

--- a/.github/workflows/prcomment.yml
+++ b/.github/workflows/prcomment.yml
@@ -2,8 +2,7 @@ name: PR Commenter
 
 on:
   pull_request:
-    branch:
-      - develop
+    branches:
       - master
 
 jobs:


### PR DESCRIPTION
### Pull Request
---

#### PR Summary
The `branches` key was incorrectly `branch`, causing the admin checklist to be posted on all PRs

#### Check the types of changes present in this PR:
- [x] :bug: Bug
- [ ] :dragon: Feature
- [ ] :frog: Data (data folder - people/opportunities)
- [ ] :dog: Content (content folder)
- [x] :blowfish: Other. Specify:

#### Checklist:
- [x] Commitizen was used for all commits.
- [x] Local site looks as expected after changes.
- [x] Contributing guidelines were followed.
- [x] If changes affect development, was the README updated?

##### If PR to `production`
- [ ] Development site (https://datasci.brown.edu) was checked and looks as expected.
