### PR TITLE
ci: only add 2 day wait to content and other PRs

### DIFF
--- a/.github/workflows/pr-release-comment.yml
+++ b/.github/workflows/pr-release-comment.yml
@@ -33,7 +33,7 @@ jobs:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         label: "4 day wait"
     - name: Add 2 day wait
-      if: (!contains(steps.pr_type.outputs.change_types, 'feature'))
+      if: contains(steps.pr_type.outputs.change_types, 'content') || contains(steps.pr_type.outputs.change_types, 'other')
       uses: brown-ccv/gh-actions/add-pr-label@master
       with:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
### Pull Request
---

#### PR Summary
Instead of applying 2 day wait to all PRs that aren't good `feature`, only add it to `content` and `Other`

#### Check the types of changes present in this PR:
- [ ] :bug: Bug
- [ ] :dragon: Feature
- [ ] :frog: Data (data folder - people/opportunities)
- [ ] :dog: Content (content folder)
- [x] :blowfish: Other. Specify: ci

#### Checklist:
- [x] Commitizen was used for all commits.
- [x] Local site looks as expected after changes.
- [x] Contributing guidelines were followed.
- [x] If changes affect development, was the README updated?

##### If PR to `production`
- [ ] Development site (https://datasci.brown.edu) was checked and looks as expected.
