### PR TITLE
ci: move labeling to master PRs, update readme

### DIFF
--- a/.github/workflows/pr-release-comment.yml
+++ b/.github/workflows/pr-release-comment.yml
@@ -26,15 +26,3 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         message_id: "Release"
         message_file: '.github/CODE_REVIEW/release.md'
-    - name: Add 4 day wait
-      if: contains(steps.pr_type.outputs.change_types, 'feature')
-      uses: brown-ccv/gh-actions/add-pr-label@master
-      with:
-        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-        label: "4 day wait"
-    - name: Add 2 day wait
-      if: contains(steps.pr_type.outputs.change_types, 'content') || contains(steps.pr_type.outputs.change_types, 'other')
-      uses: brown-ccv/gh-actions/add-pr-label@master
-      with:
-        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-        label: "2 day wait"

--- a/.github/workflows/prcomment.yml
+++ b/.github/workflows/prcomment.yml
@@ -40,3 +40,21 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         message_id: "Content 2"
         message_file: '.github/CODE_REVIEW/content_2nd.md'
+    - name: Add 4 day wait
+      if: contains(steps.pr_type.outputs.change_types, 'feature')
+      uses: brown-ccv/gh-actions/add-pr-label@master
+      with:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        label: "4 day wait"
+    - name: Add 2 day wait
+      if: contains(steps.pr_type.outputs.change_types, 'content') || contains(steps.pr_type.outputs.change_types, 'other')
+      uses: brown-ccv/gh-actions/add-pr-label@master
+      with:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        label: "2 day wait"
+    - name: Add Ready Label
+      if: contains(steps.pr_type.outputs.change_types, 'data') || contains(steps.pr_type.outputs.change_types, 'bug') && !(contains(steps.pr_type.outputs.change_types, 'content') || contains(steps.pr_type.outputs.change_types, 'other') || contains(steps.pr_type.outputs.change_types, 'feature'))
+      uses: brown-ccv/gh-actions/add-pr-label@master
+      with:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        label: "ready"

--- a/README.md
+++ b/README.md
@@ -136,7 +136,10 @@ When a PR is merged into `master`, the topic branch that originates the PR is au
 
 A checklist will be created in the comments section of the PR. Follow those instructions and use the checklist. And review the website deployed to Heroku.
 
-The reviewer who merged the PR into `master` is responsible for starting a PR to `production` and assigning it to the `website-admin` team.
+The reviewer who merged the PR into `master` is responsible for starting a PR to `production` and assigning it to the `website-admin` team once the waiting period (if applicable) is complete.  Wait times are automatically tracked with the `2 day wait` and `4 day wait` labels and changed to `ready` when 48 or 96 non-weekend hours have lapsed since the last commit.  The wait times are as follows:
+* **content**, **other** - 2 days
+* **new feature** - 4 days
+* **data**, **hotfix**, **styles** - No wait
 
 The member from the `website-admin` will announce on the slack channel `gh-ccv-website` the waiting period for the PR to give everyone interested a chance to look at the staging site.
 


### PR DESCRIPTION
### Pull Request
---

#### PR Summary
Currently wait times are enforced on merges to production.  This PR moves that to master.  This will make managing multiple PRs easier as if there are objections they will be raised before merging with other already approved PRs.  Now production PRs can happen immediately after merge (assuming admins approve)

#### Check the types of changes present in this PR:
- [ ] :bug: Bug
- [ ] :dragon: Feature
- [ ] :frog: Data (data folder - people/opportunities)
- [ ] :dog: Content (content folder)
- [x] :blowfish: Other. Specify: CI

#### Checklist:
- [x] Commitizen was used for all commits.
- [x] Local site looks as expected after changes.
- [x] Contributing guidelines were followed.
- [x] If changes affect development, was the README updated?

##### If PR to `production`
- [ ] Development site (https://datasci.brown.edu) was checked and looks as expected.
