### PR TITLE
feat: 🎸 move rates table to shortcut and convert to HTML

### DIFF
--- a/content/english/services/rates.md
+++ b/content/english/services/rates.md
@@ -12,19 +12,8 @@ lead: We provide services with limited resources at **no cost** to all
 ---
 # High-performance Computing (Oscar)
 
-{{% table c="striped" hover="false" w="100" head="dark" %}}
+{{< rates >}}
 
-| Account(s) Type | CPU Cores and Walltime | Cost | Description |
-| --- | --- | --- | --- |
-| Exploratory (PI Sponsored) | 32 for 48 hours per job, 2 std GPUs for 48 hours† | Free† | Available to all members affiliated with Brown |
-| Exploratory (No PI) | 32 for 48 Hours | Free | No Data Directory is assigned |
-| HPC Priority |208 for 96 hours | $200/user/quarter | For CPU intensive workloads |
-| HPC Priority+ | 416 for 96 hours | $400/user/quarter | For CPU intensive workloads |
-| HPC GPU Priority Standard | 4 std GPU for 96 hours, Titan RTX or lower | $200/user/quarter | Basic GPU intensive workloads |
-| HPC GPU Priority Standard+ | 8 std GPU for 96 hours, Titan RTX or lower‡ | $400/user/quarter | For workloads that require multiple GPUs
-| HPC GPU Priority High End | 4 high-end GPU for 96 hours, Tesla V100‡ | $400/user/quarter | For workloads that require High-end GPUs
-| HPC Priority Large Memory | 32 cores for 96 hours with 760GB real memory or 2TB Virtual | $100/user/quarter | For very memory-intensive workloads
-| Condo Rental | 256 Cores | $10,000 | No wall-time limits |
 
 > Each account is assigned 20G Home, 512G Scratch (purged every 30 days), and 256G Data Directory (shared amongst members of the group) by default. Except for no-PI exploratory accounts, they do not get a Data directory.
 
@@ -39,7 +28,6 @@ lead: We provide services with limited resources at **no cost** to all
 | Advanced Support | Any staff services requiring more than 1 week's effort per year | $85/hour |
 | Project Collaboration | Percent time of a specific staff member charged directly to the grant | %FTE |
 
-{{% /table %}}
 
 # Research Data Storage
 

--- a/themes/gb-theme/layouts/_default/single.html
+++ b/themes/gb-theme/layouts/_default/single.html
@@ -14,7 +14,7 @@
 <section id="section-1" class="bg-light">
   <div class="container-fluid d-flex justify-content-center px-0">
     <div class="col-lg-8 col-md-10 col-sm-12 py-10">
-      {{ .Content }}
+      {{ .Content | safeHTML }}
     </div>
   </div>
 </section>

--- a/themes/gb-theme/layouts/shortcodes/rates.html
+++ b/themes/gb-theme/layouts/shortcodes/rates.html
@@ -16,7 +16,7 @@
       <td>Individual Exploratory (no PI)</td>
       <td>32 <br> 4 <br> 32</td>
       <td>246 <br> 192 <br> 768</td>
-      <td>No GPUs <br> 2 Standard GPUs <br> No GPUs </td>
+      <td>No GPUs <br> 2 Std. GPUs <br> No GPUs </td>
       <td>48</td>
       <td>No</td>
       <td>$0</td>
@@ -26,7 +26,7 @@
       <td>Sponsored Exploratory (with PI)</td>
       <td>32 <br> 4 <br> 32</td>
       <td>246 <br> 192 <br> 768</td>
-      <td>No GPUs <br> 2 Standard GPUs <br> No GPUs </td>
+      <td>No GPUs <br> 2 Std. GPUs <br> No GPUs </td>
       <td>48</td>
       <td>Yes</td>
       <td>$0</td>
@@ -36,7 +36,7 @@
       <td>HPC Priority</td>
       <td>208</td>
       <td>1,500</td>
-      <td>2 Standard GPUs</td>
+      <td>2 Std. GPUs</td>
       <td>96</td>
       <td>Yes</td>
       <td>$200</td>
@@ -46,7 +46,7 @@
       <td>HPC Priority+</td>
       <td>416</td>
       <td>3,000</td>
-      <td>2 Standard GPUs</td>
+      <td>2 Std. GPUs</td>
       <td>96</td>
       <td>Yes</td>
       <td>$400</td>
@@ -54,9 +54,9 @@
     </tr>
     <tr>
       <td>Standard GPU Priority</td>
-      <td>8</td>
+      <td>16</td>
       <td>192</td>
-      <td>4 Standard GPUs</td>
+      <td>4 Std. GPUs</td>
       <td>96</td>
       <td>Yes</td>
       <td>$200</td>
@@ -66,17 +66,7 @@
       <td>Standard GPU Priority+</td>
       <td>16</td>
       <td>384</td>
-      <td>8 Standard GPUs</td>
-      <td>96</td>
-      <td>Yes</td>
-      <td>$400</td>
-      <td>GPU</td>
-    </tr>
-    <tr>
-      <td>Standard GPU Priority+</td>
-      <td>16</td>
-      <td>384</td>
-      <td>8 Standard GPUs</td>
+      <td>8 Std. GPUs</td>
       <td>96</td>
       <td>Yes</td>
       <td>$400</td>
@@ -104,13 +94,13 @@
     </tr>
     <tr>
       <td>Condo Rental	</td>
-      <td>2,000G</td>
+      <td>512</td>
       <td>2TB</td>
       <td>-</td>
       <td>No wall-time limits</td>
       <td>Yes</td>
       <td>$10,000 (Yearly)</td>
-      <td>Condo</td>
+      <td>Batch</td>
     </tr>
   </tbody>
 </table>

--- a/themes/gb-theme/layouts/shortcodes/rates.html
+++ b/themes/gb-theme/layouts/shortcodes/rates.html
@@ -1,0 +1,116 @@
+<table style="width: 125%; margin-left:-10%;">
+  <thead>
+    <tr>
+      <th>Account(s) Type</th>
+      <th>CPU Cores</th>
+      <th>Memory(GB)</th>
+      <th>GPU</th>
+      <th>Max Walltime* (Hours)</th>
+      <th>Data Directory</th>
+      <th> Cost (Billed Quarterly)</th>
+      <th>Partition</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Individual Exploratory (no PI)</td>
+      <td>32 <br> 4 <br> 32</td>
+      <td>246 <br> 192 <br> 768</td>
+      <td>No GPUs <br> 2 Standard GPUs <br> No GPUs </td>
+      <td>48</td>
+      <td>No</td>
+      <td>$0</td>
+      <td>Batch <br> GPU <br> Bigmem</td>
+    </tr>
+    <tr>
+      <td>Sponsored Exploratory (with PI)</td>
+      <td>32 <br> 4 <br> 32</td>
+      <td>246 <br> 192 <br> 768</td>
+      <td>No GPUs <br> 2 Standard GPUs <br> No GPUs </td>
+      <td>48</td>
+      <td>Yes</td>
+      <td>$0</td>
+      <td>Batch <br> GPU <br> Bigmem</td>
+    </tr>
+    <tr>
+      <td>HPC Priority</td>
+      <td>208</td>
+      <td>1,500</td>
+      <td>2 Standard GPUs</td>
+      <td>96</td>
+      <td>Yes</td>
+      <td>$200</td>
+      <td>Batch</td>
+    </tr>
+    <tr>
+      <td>HPC Priority+</td>
+      <td>416</td>
+      <td>3,000</td>
+      <td>2 Standard GPUs</td>
+      <td>96</td>
+      <td>Yes</td>
+      <td>$400</td>
+      <td>Batch</td>
+    </tr>
+    <tr>
+      <td>Standard GPU Priority</td>
+      <td>8</td>
+      <td>192</td>
+      <td>4 Standard GPUs</td>
+      <td>96</td>
+      <td>Yes</td>
+      <td>$200</td>
+      <td>GPU</td>
+    </tr>
+    <tr>
+      <td>Standard GPU Priority+</td>
+      <td>16</td>
+      <td>384</td>
+      <td>8 Standard GPUs</td>
+      <td>96</td>
+      <td>Yes</td>
+      <td>$400</td>
+      <td>GPU</td>
+    </tr>
+    <tr>
+      <td>Standard GPU Priority+</td>
+      <td>16</td>
+      <td>384</td>
+      <td>8 Standard GPUs</td>
+      <td>96</td>
+      <td>Yes</td>
+      <td>$400</td>
+      <td>GPU</td>
+    </tr>
+    <tr>
+      <td>High End GPU Priority</td>
+      <td>16</td>
+      <td>256</td>
+      <td>4 high-end GPUs (Tesla V100)</td>
+      <td>96</td>
+      <td>Yes</td>
+      <td>$400</td>
+      <td>GPU</td>
+    </tr>
+    <tr>
+      <td>Large Memory Priority</td>
+      <td>32</td>
+      <td>2TB</td>
+      <td>-</td>
+      <td>96</td>
+      <td>Yes</td>
+      <td>$100</td>
+      <td>Bigmem</td>
+    </tr>
+    <tr>
+      <td>Condo Rental	</td>
+      <td>2,000G</td>
+      <td>2TB</td>
+      <td>-</td>
+      <td>No wall-time limits</td>
+      <td>Yes</td>
+      <td>$10,000 (Yearly)</td>
+      <td>Condo</td>
+    </tr>
+  </tbody>
+</table>


### PR DESCRIPTION
### Pull Request
---

#### PR Summary
Update rates table, move to a shortcode as it's now HTML.
@singhsaluja  @yangliu2009 the table is now at:`ccv-website/themes/gb-theme/layouts/shortcodes/rates.html`

@singhsaluja @yangliu2009, can you take it from here and address changes if requested?

Please, review the content with attention as I just copied and pasted things.

Eventually we want to move the data out of the template, but for now, this should work.

#### Check the types of changes present in this PR:
- [ ] :bug: Bug
- [x] :dragon: Feature
- [x] :frog: Data (data folder - people/opportunities)
- [ ] :dog: Content (content folder)
- [ ] :blowfish: Other. Specify:

#### Checklist:
- [x] Commitizen was used for all commits.
- [x] Local site looks as expected after changes.
- [x] Contributing guidelines were followed.
- [ ] If changes affect development, was the README updated?

##### If PR to `production`
- [ ] Development site (https://datasci.brown.edu) was checked and looks as expected.
