### PR TITLE
fix: fix description of hpc resource eligibility

### DIFF
--- a/content/english/covid/_index.md
+++ b/content/english/covid/_index.md
@@ -39,6 +39,11 @@ items:
         will be providing the JHU CSSE COVID-19 dataset with daily updates. Other public
         datasets that are needed may be added on request, if reasonable.
 
+        Any Brown faculty member whose salary is paid by Brown or whose research is administered
+        through Brown is eligible to be a Principal Investigator. Brown faculty employed by 
+        affiliated institutions, or Brown faculty whose research is administered through affiliated 
+        institutions, may be included as co-PIs on the research team.
+
         Please email [support@ccv.brown.edu](mailto:support@ccv.brown.edu) to ask for
         this service and CCV will work with OVPR to vet and approve the request.
 

--- a/themes/gb-theme/layouts/covid/list.html
+++ b/themes/gb-theme/layouts/covid/list.html
@@ -37,7 +37,7 @@
 
     <!-- sections -->
     {{ range .Params.items }}
-    <header id="{{ .name }}-section" class="d-flex align-items-center pt-6">
+    <header id="{{ .name }}" class="d-flex align-items-center pt-6">
       <span class="btn-red text-light btn-ico btn-lg btn-rounded d-flex align-items-center justify-content-center">
         <i class="fas fa-{{ .icon}} fs-36"></i>
       </span>


### PR DESCRIPTION
This PR fixes the description of HPC resources for covid. This resolves issue `239`.
closes #239, closes #240 

#### Check the types of changes present in this PR:
- [x] :bug: Bug
- [ ] :dragon: Feature
- [ ] :frog: Data (data folder - people/opportunities)
- [ ] :dog: Content (content folder)
- [ ] :blowfish: Other. Specify:

#### Checklist:
- [ ] Commitizen was used for all commits.
- [ ] Local site looks as expected after changes.
- [ ] Contributing guidelines were followed.
- [ ] If changes affect development, was the README updated?

##### If PR to `production`
- [ ] Development site (https://datasci.brown.edu) was checked and looks as expected.
