### PR TITLE
fix: fixes broken markdown on storage table

### DIFF
--- a/content/english/services/infrastructure/storage.md
+++ b/content/english/services/infrastructure/storage.md
@@ -9,8 +9,7 @@ draft: false
 lead: Several services at Brown allow you to share and store files. This guide will let you compare the options and decide which one(s) are right for you.
 ---
 
-
- | Google Drive | Dropbox | BrownBox | Campus File Storage | RData | Stronghold   
+| | Google Drive | Dropbox | BrownBox | Campus File Storage | RData | Stronghold
 -----  |  -----  |  ------ |  ------ |  ------ |  ------ |  ------  
 Collaborative editing | {{< fas check >}} |   |   |   |   |  
 Easy access from smartphones | {{< fas check >}} | {{< fas check >}} |   |   |   |  


### PR DESCRIPTION
### Pull Request
This pull request fixes the broken markdown on the storage comparison table. 

#### PR Summary
I just added a `|` to the markdown to fix the misaligned header of the storage comparison table. This should resolve issue #262. 

#### Check the types of changes present in this PR:
- [ ] :bug: Bug
- [ ] :dragon: Feature
- [ ] :frog: Data (data folder - people/opportunities)
- [ ] :dog: Content (content folder)
- [x] :blowfish: Other. Specify:

#### Checklist:
- [x] Commitizen was used for all commits.
- [x] Local site looks as expected after changes.
- [x] Contributing guidelines were followed.
- [ ] If changes affect development, was the README updated?

##### If PR to `production`
- [ ] Development site (https://datasci.brown.edu) was checked and looks as expected.
