### PR TITLE
fix: fix to add downtime banner

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -93,11 +93,11 @@ params:
     ccvGithub: https://github.com/brown-ccv/
     cbcGithub: https://github.com/compbiocore/it
 
-  covid:
-    title: COVID-19 Updates
+  upgrade:
+    title: Oscar Planned Outage
     text: |
-      The Center for Computation and Visualization remains committed to supporting
-      the computing needs of the Brown Research Community during this difficult time.
+      CCV's High Performance Computing Cluster ("Oscar") will unavailable from June 22 to June 28 for 
+      planned upgrades.
 
 # i18n
 languages:

--- a/config.yml
+++ b/config.yml
@@ -96,7 +96,7 @@ params:
   upgrade:
     title: Oscar Planned Outage
     text: |
-      CCV's High Performance Computing Cluster ("Oscar") will unavailable from June 22 to June 28 for 
+      CCV's High-Performance Computing Cluster ("Oscar") will be unavailable from June 22 to June 28 for 
       planned upgrades.
 
 # i18n

--- a/content/english/upgrade/_index.md
+++ b/content/english/upgrade/_index.md
@@ -1,0 +1,30 @@
+---
+title: Oscar Upgrade
+
+tagTitle: Oscar Upgrade
+hero:
+  lead: The Oscar cluster will be unavailable for scheduled maintenance, beginning Monday, June 22, 2020 at 8:00 am to Monday, June 29, 2020.
+
+lastUpdated: 18 June 2020
+
+items:
+- name: statement
+  title: Oscar Planned Outage Details
+  icon: cog
+  text: |
+        The Oscar cluster will be unavailable for scheduled maintenance, beginning Monday, June 22, 2020 at 8:00 am to Monday, June 29, 2020.
+
+        We expect to bring the cluster back online much sooner than published downtime, but have lengthened the downtime in case of unforeseen problems. Without issues, the downtime should be 3-4 days.
+
+        Following services will be unavailable during the downtime:
+
+          - SSH Login
+          - VNC
+          - File System Mounts (CIFS, SMB)
+
+        Existing jobs and VNC sessions will terminate. Any Slurm jobs in the queue that can’t finish before 8 am on the morning of the downtime won’t run. They will remain in the queue until the nodes are released back into production on June 29, 2020 (or earlier).
+
+        During this downtime, we will perform several maintenance tasks, including upgrading the GPFS file-system. An update will be sent once the cluster is back in production.
+
+        If you have any questions or concerns please let us know at support@ccv.brown.edu
+---

--- a/themes/gb-theme/assets/styles/custom/components/_upgrade.scss
+++ b/themes/gb-theme/assets/styles/custom/components/_upgrade.scss
@@ -1,0 +1,4 @@
+.upgrade-section {
+    padding-top: 0.2rem;
+    padding-bottom: 0.2rem;
+}

--- a/themes/gb-theme/assets/styles/custom/custom.scss
+++ b/themes/gb-theme/assets/styles/custom/custom.scss
@@ -21,5 +21,6 @@
 @import "components/_calendar";
 @import "components/_search";
 @import "components/_covid";
+@import "components/_upgrade";
 @import "components/_confetti";
 @import "components/_blocks";

--- a/themes/gb-theme/layouts/partials/blocks/upgrade.html
+++ b/themes/gb-theme/layouts/partials/blocks/upgrade.html
@@ -1,0 +1,7 @@
+<section class="bg-beige upgrade-section">
+   <div class="message-banner container py-1">
+      <h5 class="text-primary">{{ .Site.Params.upgrade.text }}
+         <a href="upgrade/" class="btn btn-danger px-1 py-0"><i class="fas fa-cog"></i> {{ .Site.Params.upgrade.title }}</a>
+      </h5>
+   </div>
+</section>

--- a/themes/gb-theme/layouts/partials/header/site-nav.html
+++ b/themes/gb-theme/layouts/partials/header/site-nav.html
@@ -25,4 +25,4 @@
   </div>
 </section>
 
-{{ partial "blocks/covid" . }}
+{{ partial "blocks/upgrade" . }}

--- a/themes/gb-theme/layouts/upgrade/list.html
+++ b/themes/gb-theme/layouts/upgrade/list.html
@@ -1,0 +1,39 @@
+{{ define "content" }}
+<!-- header - yellow container -->
+{{ $current_section := .Section }}
+<div id="hero-list" class=" bg-yellow text pb-5">
+  <div class="container">
+    <div class="row">
+      <div class="col-md-12 d-flex flex-column pt-6 pb-10">
+        <h1 class="fs-60">Oscar Upgrade</h1>
+        <p class="fs-30">{{ .Params.hero.lead | markdownify }}</p>
+      </div>
+    </div>
+  </div>
+</div>
+
+
+
+<div class="container-fluid d-flex justify-content-center py-10 px-0">
+  <div class="col-lg-9 col-md-11 col-sm-12">
+    <small class="small">Last Updated: {{ .Params.lastUpdated }}</small>
+
+    <!-- sections -->
+    {{ range .Params.items }}
+    <header id="{{ .name }}" class="d-flex align-items-center pt-6">
+      <span class="btn-red text-light btn-ico btn-lg btn-rounded d-flex align-items-center justify-content-center">
+        <i class="fas fa-{{ .icon}} fs-36"></i>
+      </span>
+      <h1 class="mx-4 text-secondary">{{ title .title }}</h1>
+      <hr class="bg-dark w-40" />
+    </header>
+
+    <article id="{{ .name }}-content" class="py-4">
+      <p class="p-medium">{{ .text | markdownify }}</p>
+    </article>
+    {{ end }}
+
+  </div>
+</div>
+
+{{ end }}


### PR DESCRIPTION
### Pull Request
This PR adds the outage banner notification

#### PR Summary
This PR replaces the covid banner with an alert regarding the impending downtime for system upgrade

#### Check the types of changes present in this PR:
- [x] :bug: Bug
- [ ] :dragon: Feature
- [ ] :frog: Data (data folder - people/opportunities)
- [ ] :dog: Content (content folder)
- [ ] :blowfish: Other. Specify:

#### Checklist:
- [x] Commitizen was used for all commits.
- [x] Local site looks as expected after changes.
- [x] Contributing guidelines were followed.
- [ ] If changes affect development, was the README updated?

##### If PR to `production`
- [ ] Development site (https://datasci.brown.edu) was checked and looks as expected.
