### PR TITLE
fix: fix broken cbc github link

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -91,7 +91,7 @@ params:
       link: https://join.slack.com/t/ccv-share/shared_invite/enQtODY5OTQ3MTk0ODU1LTM4OWQyZjVlYWRmY2QxNWEyZjQ0NzEwMmRlNTRlZjYyMjM1Y2U5MDU1ZGFmMmRhZWIzNjliYmQzYTBiMzY2NzU
   githubLinks:
     ccvGithub: https://github.com/brown-ccv/
-    cbcGithub: https://github.com/compbiocore/it
+    cbcGithub: https://github.com/compbiocore/
 
   upgrade:
     title: Oscar Planned Outage


### PR DESCRIPTION
### Pull Request
Fixes broken link to CBC GitHub

#### PR Summary
This PR corrects a typo and thereby fixes a broken link to the Comp Bio Core's GitHub page.

#### Check the types of changes present in this PR:
- [x] :bug: Bug
- [ ] :dragon: Feature
- [ ] :frog: Data (data folder - people/opportunities)
- [ ] :dog: Content (content folder)
- [ ] :blowfish: Other. Specify:

#### Checklist:
- [x] Commitizen was used for all commits.
- [x] Local site looks as expected after changes.
- [x] Contributing guidelines were followed.
- [x] If changes affect development, was the README updated?

##### If PR to `production`
- [ ] Development site (https://datasci.brown.edu) was checked and looks as expected.
