### PR TITLE
fix: revert to covid banner

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -93,11 +93,11 @@ params:
     ccvGithub: https://github.com/brown-ccv/
     cbcGithub: https://github.com/compbiocore/it
 
-  upgrade:
-    title: Oscar Planned Outage
+  covid:
+    title: COVID-19 Updates
     text: |
-      Oscar scheduled maintenance - June 22, 2020 at 8:00 am - June 29, 2020 at 5:00 pm
-
+      The Center for Computation and Visualization remains committed to supporting
+      the computing needs of the Brown Research Community during this difficult time.
 # i18n
 languages:
   en:

--- a/themes/gb-theme/layouts/partials/header/site-nav.html
+++ b/themes/gb-theme/layouts/partials/header/site-nav.html
@@ -25,4 +25,4 @@
   </div>
 </section>
 
-{{ partial "blocks/upgrade" . }}
+{{ partial "blocks/covid" . }}


### PR DESCRIPTION
### Pull Request
Revert to covid banner

#### PR Summary
This PR removes the downtime message and reverts to the covid banner we previously used.

#### Check the types of changes present in this PR:
- [x] :bug: Bug
- [ ] :dragon: Feature
- [ ] :frog: Data (data folder - people/opportunities)
- [ ] :dog: Content (content folder)
- [ ] :blowfish: Other. Specify:

#### Checklist:
- [x] Commitizen was used for all commits.
- [x] Local site looks as expected after changes.
- [x] Contributing guidelines were followed.
- [x] If changes affect development, was the README updated?

##### If PR to `production`
- [ ] Development site (https://datasci.brown.edu) was checked and looks as expected.
