### PR TITLE
fix: remove unconf card in whatsnew section

### DIFF
--- a/data/whatsnew.yaml
+++ b/data/whatsnew.yaml
@@ -6,15 +6,15 @@ items:
     fa:
       prefix: fad
       icon: fa-database
-  - title: Brown Unconf
-    text: The Carney Institute for Brain Science, the Data Science Initiative, and CCV are sponsoring the [Brown Unconference on Computational Intelligence and Applications](https://serre-lab.github.io/BrownUnconf.github.io/)
-    fa:
-      prefix: fad
-      icon: fa-satellite-dish
   - title: COVID-19 Updates
     text: The Center for Computation and Visualization remains committed to supporting the computing needs of the Brown Research Community during this difficult time. [**Click here for details.**](covid/)
     fa:
       prefix: fad
       icon: fa-shield-virus
+  - title: New CCV rates
+    text: Check the new rates for our consulting services and infrastructure. [**Click here for details.**](services/rates/)
+    fa:
+      prefix: fad
+      icon: fa-sack-dollar
 
 


### PR DESCRIPTION
### Pull Request
Remove the unconf card from what's new

#### PR Summary
This PR removes the link to the (now-completed) Unconference that was held at couple of weeks ago. And I added back the link to the updated rates section

#### Check the types of changes present in this PR:
- [ ] :bug: Bug
- [ ] :dragon: Feature
- [x] :frog: Data (data folder - people/opportunities)
- [ ] :dog: Content (content folder)
- [ ] :blowfish: Other. Specify:

#### Checklist:
- [x] Commitizen was used for all commits.
- [x] Local site looks as expected after changes.
- [x] Contributing guidelines were followed.
- [x] If changes affect development, was the README updated?

##### If PR to `production`
- [ ] Development site (https://datasci.brown.edu) was checked and looks as expected.
