### PR TITLE
fix: fix fiscal year to be 2021

### DIFF
--- a/content/english/services/rates.md
+++ b/content/english/services/rates.md
@@ -4,10 +4,10 @@ title: Rates
 tagTitle: Rates - Center for Computation and Visualization
 tagDescription: Check rates for advanced research computing that require extra resources.
 
-date: 2019-03-12T10:58:51.000+00:00
+date: 2020-08-05T18:04:51.000+00:00
 lead: We provide services with limited resources at **no cost** to all
   members affiliated with Brown. For advanced computing that requires extra resources,
-  we charge a quarterly fee. See below the rates for FY20
+  we charge a quarterly fee. See below the rates for FY21
 
 ---
 # High Performance Computing Cluster (Oscar)


### PR DESCRIPTION
### Pull Request
This is just fixing the fiscal year on the rates page

#### PR Summary
This PR closes #300 by fixing the current fiscal year on the rates page to be FY2021


#### Check the types of changes present in this PR:
- [x] :bug: Bug
- [ ] :dragon: Feature
- [ ] :frog: Data (data folder - people/opportunities)
- [ ] :dog: Content (content folder)
- [ ] :blowfish: Other. Specify:

#### Checklist:
- [x] Commitizen was used for all commits.
- [ ] Local site looks as expected after changes.
- [ ] Contributing guidelines were followed.
- [ ] If changes affect development, was the README updated?

##### If PR to `production`
- [ ] Development site (https://datasci.brown.edu) was checked and looks as expected.
