### PR TITLE
fix: remove rates card from whatsnew

### DIFF
--- a/data/whatsnew.yaml
+++ b/data/whatsnew.yaml
@@ -11,10 +11,3 @@ items:
     fa:
       prefix: fad
       icon: fa-shield-virus
-  - title: CCV Rates
-    text: Check the rates for our consulting services and infrastructure. [**Click here for details.**](services/rates/)
-    fa:
-      prefix: fad
-      icon: fa-sack-dollar
-
-

--- a/data/whatsnew.yaml
+++ b/data/whatsnew.yaml
@@ -11,8 +11,8 @@ items:
     fa:
       prefix: fad
       icon: fa-shield-virus
-  - title: New CCV rates
-    text: Check the new rates for our consulting services and infrastructure. [**Click here for details.**](services/rates/)
+  - title: CCV Rates
+    text: Check the rates for our consulting services and infrastructure. [**Click here for details.**](services/rates/)
     fa:
       prefix: fad
       icon: fa-sack-dollar


### PR DESCRIPTION
### Pull Request
Removes the word "new" from the rates card on the front page

#### PR Summary
This PR removes the word "new" from the `Rates` card on the front page. These are the rates we announced 1 year ago, so calling them "new" feels odd.

#### Check the types of changes present in this PR:
- [x] :bug: Bug
- [ ] :dragon: Feature
- [ ] :frog: Data (data folder - people/opportunities)
- [ ] :dog: Content (content folder)
- [ ] :blowfish: Other. Specify:

#### Checklist:
- [x] Commitizen was used for all commits.
- [x] Local site looks as expected after changes.
- [x] Contributing guidelines were followed.
- [x] If changes affect development, was the README updated?

##### If PR to `production`
- [ ] Development site (https://datasci.brown.edu) was checked and looks as expected.
