### PR TITLE
style: 💄 Hiding 3 Services Cards

### DIFF
--- a/content/english/services/infrastructure/brown-box.md
+++ b/content/english/services/infrastructure/brown-box.md
@@ -1,4 +1,5 @@
 ---
+hidden: true
 title: BrownBox
 
 tagTitle: BrownBox - Center for Computation and Visualization

--- a/content/english/services/infrastructure/globus.md
+++ b/content/english/services/infrastructure/globus.md
@@ -1,5 +1,4 @@
 ---
-hidden: true
 title: Globus
 
 tagTitle: Globus

--- a/content/english/services/infrastructure/globus.md
+++ b/content/english/services/infrastructure/globus.md
@@ -1,4 +1,5 @@
 ---
+hidden: true
 title: Globus
 
 tagTitle: Globus

--- a/content/english/services/infrastructure/isilon.md
+++ b/content/english/services/infrastructure/isilon.md
@@ -1,4 +1,5 @@
 ---
+hidden: true
 title: Campus File Service
 
 tagTitle: Campus File Storage - Center for Computation and Visualization

--- a/content/english/services/infrastructure/rdata.md
+++ b/content/english/services/infrastructure/rdata.md
@@ -1,4 +1,5 @@
 ---
+hidden: true
 title: RData
 
 tagTitle: RData - Center for Computation and Visualization

--- a/themes/gb-theme/layouts/_default/list.html
+++ b/themes/gb-theme/layouts/_default/list.html
@@ -70,6 +70,7 @@
         <article class="d-flex py-6 justify-content-between flex-wrap">
           {{ range where $.Site.Pages "Section" $current_section}}
           {{ if eq (.Params.category | urlize) $key }}
+		  {{ if not .Params.hidden }}
           {{ $weight := .Params.weight }}
           <div class="{{if eq .Title "Advanced Research Computing"}}col-md-12{{else}}col-md-6{{end}} py-3">
             <div class="card p-4">
@@ -98,6 +99,7 @@
               </span>
             </div>
           </div>
+		  {{ end }}
           {{ end }}
           {{ end }}
       </article>


### PR DESCRIPTION
Adds a hidden key to brown-box, globus, and isilon files and adds a
conditional to html code (themes/gb-theme/layouts/_default/list.html) to
only display cards that do not have hidden: true

### Pull Request
---

#### PR Summary
Briefly describe the changes.

#### Check the types of changes present in this PR:
- [ ] :bug: Bug
- [ ] :dragon: Feature
- [ ] :frog: Data (data folder - people/opportunities)
- [x] :dog: Content (content folder)
- [ ] :blowfish: Other. Specify:

#### Checklist:
- [x] Commitizen was used for all commits.
- [x] Local site looks as expected after changes.
- [x] Contributing guidelines were followed.
- [x] If changes affect development, was the README updated?

##### If PR to `production`
- [ ] Development site (https://datasci.brown.edu) was checked and looks as expected.
