### PR TITLE
data: add open user services position

### DIFF
--- a/data/opportunities.yaml
+++ b/data/opportunities.yaml
@@ -1,7 +1,7 @@
-# - title: Research Services Support Specialist
-#   team: CCV Operations
-#   subteam: User Services
-#   link: "https://brown.wd5.myworkdayjobs.com/en-US/staff-careers-brown/job/180-George-Street/Research-Services-Support-Specialist_REQ151702"
+- title: Research Computing Specialist
+  team: CCV Operations
+  subteam: User Services
+  link: "https://brown.wd5.myworkdayjobs.com/en-US/staff-careers-brown/job/180-George-Street/Research-Computing-Analyst_REQ168211"
 # - title: Research Software Engineer
 #   team: Advanced Research Computing
 #   subteam: High-Performance Computing
@@ -14,5 +14,5 @@
 #   team: Advanced Research Computing
 #   subteam: Computational Biology Core
 #   link: "https://brown.wd5.myworkdayjobs.com/en-US/staff-careers-brown/job/3-Davol-Square/Research-Software-Engineer_REQ163610"
-- title: There are no positions open at the moment
-  team: Check back with us in the future. We appreciate your interest!
+# - title: There are no positions open at the moment
+#   team: Check back with us in the future. We appreciate your interest!


### PR DESCRIPTION
This PR updates our `Openings` section of the about page in order to include the opening in User Services.


#### Check the types of changes present in this PR:
- [ ] :bug: Bug
- [ ] :dragon: Feature
- [x] :frog: Data (data folder - people/opportunities)
- [ ] :dog: Content (content folder)
- [ ] :blowfish: Other. Specify:

#### Checklist:
- [x] Commitizen was used for all commits.
- [x] Local site looks as expected after changes.
- [x] Contributing guidelines were followed.
- [x] If changes affect development, was the README updated?

##### If PR to `production`
- [ ] Development site (https://datasci.brown.edu) was checked and looks as expected.
