### PR TITLE
feat: 🎸 add open graphics rse position

### DIFF
--- a/data/opportunities.yaml
+++ b/data/opportunities.yaml
@@ -10,9 +10,9 @@
   team: Advanced Research Computing
   subteam: Data & Visualization
   link: "https://brown.wd5.myworkdayjobs.com/en-US/staff-careers-brown/job/3-Davol-Square/Research-Software-Engineer--Senior-Research-Software-Engineer_REQ169396"
-# - title: Research Software Engineer
-#   team: Advanced Research Computing
-#   subteam: Computational Biology Core
-#   link: "https://brown.wd5.myworkdayjobs.com/en-US/staff-careers-brown/job/3-Davol-Square/Research-Software-Engineer_REQ163610"
+- title: Research Software Engineer (Graphics)
+  team: Advanced Research Computing
+  subteam: Data & Visualization
+  link: "https://brown.wd5.myworkdayjobs.com/en-US/staff-careers-brown/job/180-George-Street/Research-Software-Engineer--Graphics---Senior-Research-Software-Engineer--Graphics-_REQ170163"
 # - title: There are no positions open at the moment
 #   team: Check back with us in the future. We appreciate your interest!


### PR DESCRIPTION
BREAKING CHANGE: 🧨 no

This PR adds the Graphics RSE position to our `Opportunities` section of the `About` page.



#### Check the types of changes present in this PR:
- [ ] :bug: Bug
- [ ] :dragon: Feature
- [x] :frog: Data (data folder - people/opportunities)
- [ ] :dog: Content (content folder)
- [ ] :blowfish: Other. Specify:

#### Checklist:
- [x] Commitizen was used for all commits.
- [x] Local site looks as expected after changes.
- [x] Contributing guidelines were followed.
- [x] If changes affect development, was the README updated?

##### If PR to `production`
- [ ] Development site (https://datasci.brown.edu) was checked and looks as expected.
