### PR TITLE
prod - updates what's new and add open rse position

### DIFF
--- a/data/opportunities.yaml
+++ b/data/opportunities.yaml
@@ -10,9 +10,9 @@
   team: Advanced Research Computing
   subteam: Data & Visualization
   link: "https://brown.wd5.myworkdayjobs.com/en-US/staff-careers-brown/job/3-Davol-Square/Research-Software-Engineer--Senior-Research-Software-Engineer_REQ169396"
-# - title: Research Software Engineer
-#   team: Advanced Research Computing
-#   subteam: Computational Biology Core
-#   link: "https://brown.wd5.myworkdayjobs.com/en-US/staff-careers-brown/job/3-Davol-Square/Research-Software-Engineer_REQ163610"
+- title: Research Software Engineer (Graphics)
+  team: Advanced Research Computing
+  subteam: Data & Visualization
+  link: "https://brown.wd5.myworkdayjobs.com/en-US/staff-careers-brown/job/180-George-Street/Research-Software-Engineer--Graphics---Senior-Research-Software-Engineer--Graphics-_REQ170163"
 # - title: There are no positions open at the moment
 #   team: Check back with us in the future. We appreciate your interest!

--- a/data/whatsnew.yaml
+++ b/data/whatsnew.yaml
@@ -16,3 +16,13 @@ items:
     fa:
       prefix: fad
       icon: fa-video
+  - title: myBrown Research Tab
+    text: There is a new Research Compute tab on the myBrown portal! [**Check out the myBrown Portal!**](https://my.brown.edu/web/guest/research-compute)
+    fa:
+      prefix: fad
+      icon: fa-microscope
+  - title: Python Workshop
+    text: CCV will be hosting an introductory Python workshop. [**Check out Python workshop details.**](https://today.brown.edu/events/139280?utm_source=todayAtBrown&utm_medium=email&utm_campaign=Campus%20Faculty)
+    fa:
+      prefix: fad
+      icon: fa-hammer

--- a/data/whatsnew.yaml
+++ b/data/whatsnew.yaml
@@ -12,7 +12,7 @@ items:
       prefix: fad
       icon: fa-microscope
   - title: Python Workshop
-    text: CCV will be hosting an introductory Python workshop. [**Check out Python workshop details.**](https://today.brown.edu/events/139280?utm_source=todayAtBrown&utm_medium=email&utm_campaign=Campus%20Faculty)
+    text: CCV will be hosting an introductory Python workshop. [**Check out Python workshop details.**](https://today.brown.edu/events/139280)
     fa:
       prefix: fad
       icon: fa-hammer

--- a/data/whatsnew.yaml
+++ b/data/whatsnew.yaml
@@ -6,16 +6,6 @@ items:
     fa:
       prefix: fad
       icon: fa-door-open
-  - title: Bootcamp
-    text: CCV will be hosting a virtual bootcamp for HPC as well as computational biology! [**Check out the bootcamp details!**](https://docs.ccv.brown.edu/bootcamp2021)
-    fa:
-      prefix: fad
-      icon: fa-boot
-  - title: Oscar "How-To" Videos
-    text: CCV User Services has updated the Oscar documentation to include brief "how-to" videos for new Oscar users. [**Check out vidoes.**](https://docs.ccv.brown.edu/oscar/short-videos)
-    fa:
-      prefix: fad
-      icon: fa-video
   - title: myBrown Research Tab
     text: There is a new Research Compute tab on the myBrown portal! [**Check out the myBrown Portal!**](https://my.brown.edu/web/guest/research-compute)
     fa:


### PR DESCRIPTION
This PR updates the front page's `What's New` section and adds the open position we have for the Graphics RSE.


#### Check the types of changes present in this PR:
- [ ] :bug: Bug
- [ ] :dragon: Feature
- [x] :frog: Data (data folder - people/opportunities)
- [ ] :dog: Content (content folder)
- [ ] :blowfish: Other. Specify:

#### Checklist:
- [ ] Commitizen was used for all commits.
- [ ] Local site looks as expected after changes.
- [ ] Contributing guidelines were followed.
- [ ] If changes affect development, was the README updated?

##### If PR to `production`
- [ ] Development site (https://datasci.brown.edu) was checked and looks as expected.
