### PR TITLE
fix: remove dead opportunity link

### DIFF
--- a/data/opportunities.yaml
+++ b/data/opportunities.yaml
@@ -6,10 +6,6 @@
   team: Advanced Research Computing
   subteam: High-Performance Computing
   link: "https://brown.wd5.myworkdayjobs.com/en-US/staff-careers-brown/job/180-George-Street/Research-Software-Engineer_REQ169311"
-- title: Research Software Engineer/Senior Research Software Engineer
-  team: Advanced Research Computing
-  subteam: Data & Visualization
-  link: "https://brown.wd5.myworkdayjobs.com/en-US/staff-careers-brown/job/3-Davol-Square/Research-Software-Engineer--Senior-Research-Software-Engineer_REQ169396"
 - title: Research Software Engineer (Graphics)
   team: Advanced Research Computing
   subteam: Data & Visualization


### PR DESCRIPTION
### Pull Request
---

#### PR Summary
Link for the RSE posting was dead.

#### Check the types of changes present in this PR:
- [ ] :bug: Bug
- [ ] :dragon: Feature
- [x] :frog: Data (data folder - people/opportunities)
- [ ] :dog: Content (content folder)
- [ ] :blowfish: Other. Specify:

#### Checklist:
- [x] Commitizen was used for all commits.
- [ ] Local site looks as expected after changes.
- [ ] Contributing guidelines were followed.
- [ ] If changes affect development, was the README updated?

##### If PR to `production`
- [ ] Development site (https://datasci.brown.edu) was checked and looks as expected.
